### PR TITLE
Automatically load helpers

### DIFF
--- a/lib/preloadables/engine.rb
+++ b/lib/preloadables/engine.rb
@@ -1,4 +1,14 @@
 module Preloadables
   class Engine < ::Rails::Engine
+
+    # This ensures that Rails component based architecture apps
+    # can use the helpers without having to manually require the
+    # helpers.
+    config.before_initialize do
+      ActiveSupport.on_load :action_controller do
+        helper Preloadables::Engine.helpers
+      end
+    end
+
   end
 end


### PR DESCRIPTION
This is allowing component based rails apps to consume the helpers
without manually requiring it.

FIX: https://github.com/jacopotarantino/preloadables/issues/1
